### PR TITLE
Updated hyperlink, github actions, pinned R version

### DIFF
--- a/.github/aws/web.yml
+++ b/.github/aws/web.yml
@@ -1,0 +1,125 @@
+family: "$ECS_WEB_TASK"
+networkMode: awsvpc
+cpu: "$ECS_CPU_UNITS"
+memory: "$ECS_MEMORY_UNITS"
+executionRoleArn: "$ROLE_ARN"
+taskRoleArn: "$ROLE_ARN"
+requiresCompatibilities:
+  - FARGATE
+ephemeralStorage:
+  sizeInGiB: 100
+volumes:
+  - name: data
+    efsVolumeConfiguration:
+      fileSystemId: "$EFS_FILESYSTEM_ID"
+      authorizationConfig:
+        accessPointId: "$EFS_ACCESS_POINT_ID"
+        iam: ENABLED
+      transitEncryption: ENABLED
+containerDefinitions:
+  - name: logs
+    image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable
+    firelensConfiguration:
+      type: fluentbit
+      options:
+        enable-ecs-log-metadata: "true"
+    memoryReservation: 50
+    logConfiguration:
+      logDriver: awslogs
+      options:
+        awslogs-group: "/analysistools/$TIER/$APP"
+        awslogs-region: "$AWS_REGION"
+        awslogs-stream-prefix: logs
+
+  - name: frontend
+    image: "$FRONTEND_IMAGE_LATEST"
+    portMappings:
+      - protocol: tcp
+        containerPort: $FRONTEND_CONTAINER_PORT
+    environment:
+      - name: API_HOST
+        value: http://localhost:$BACKEND_CONTAINER_PORT
+    secrets:
+      - name: SERVER_NAME
+        valueFrom: "/analysistools/$TIER/$APP/application_host"
+    logConfiguration:
+      logDriver: awsfirelens
+      options:
+        Name: datadog
+        tls: "on"
+        tls.verify: "off"
+        dd_service: "$TIER-$APP-frontend"
+        dd_source: "httpd"
+        dd_tags: "project:$APP tier:$TIER"
+        provider: ecs
+      secretOptions:
+        - name: Host
+          valueFrom: /analysistools/$TIER/datadog/log_endpoint_host
+        - name: apikey
+          valueFrom: /analysistools/$TIER/datadog/api_key
+    memoryReservation: 100
+
+  - name: backend
+    image: "$BACKEND_IMAGE_LATEST"
+    environment:
+      - name: TZ
+        value: "America/New_York"
+      - name: AWS_REGION
+        value: "$AWS_REGION"
+      - name: APP_NAME
+        value: "$APP"
+      - name: SERVER_PORT
+        value: "$BACKEND_CONTAINER_PORT"
+      - name: WORKER_TYPE
+        value: "fargate"
+      - name: LOG_LEVEL
+        value: "$LOG_LEVEL"
+    secrets:
+      - name: EMAIL_ADMIN
+        valueFrom: "/analysistools/$TIER/$APP/email_admin"
+      - name: EMAIL_SENDER
+        valueFrom: "/analysistools/$TIER/$APP/email_sender"
+      - name: EMAIL_BASE_URL
+        valueFrom: "/analysistools/$TIER/$APP/base_url"
+      - name: SESSION_FOLDER
+        valueFrom: "/analysistools/$TIER/$APP/session_folder"
+      - name: VPC_ID
+        valueFrom: "/analysistools/$TIER/$APP/vpc_id"
+      - name: SUBNET_IDS
+        valueFrom: "/analysistools/$TIER/$APP/subnet_ids"
+      - name: SECURITY_GROUP_IDS
+        valueFrom: "/analysistools/$TIER/$APP/security_group_ids"
+      - name: ECS_CLUSTER
+        valueFrom: "/analysistools/$TIER/$APP/ecs_cluster"
+      - name: WORKER_TASK_NAME
+        valueFrom: "/analysistools/$TIER/$APP/worker/ecs_task"
+    mountPoints:
+      - sourceVolume: data
+        containerPath: "/data"
+        readOnly: false
+    logConfiguration:
+      logDriver: awsfirelens
+      options:
+        Name: datadog
+        tls: "on"
+        tls.verify: "off"
+        dd_service: "$TIER-$APP-backend"
+        dd_source: "R"
+        dd_tags: "project:$APP tier:$TIER"
+        provider: ecs
+      secretOptions:
+        - name: Host
+          valueFrom: /analysistools/$TIER/datadog/log_endpoint_host
+        - name: apikey
+          valueFrom: /analysistools/$TIER/datadog/api_key
+tags:
+  - key: Project
+    value: "$APP"
+  - key: ResourceName
+    value: "$TIER-$APP-web-ecs-task"
+  - key: EnvironmentTier
+    value: "$ENVIRONMENT_TIER"
+  - key: ResourceFunction
+    value: compute
+  - key: Creator
+    value: CF

--- a/.github/aws/worker.yml
+++ b/.github/aws/worker.yml
@@ -1,0 +1,97 @@
+family: "$ECS_WORKER_TASK"
+networkMode: awsvpc
+cpu: "$ECS_WORKER_CPU_UNITS"
+memory: "$ECS_WORKER_MEMORY_UNITS"
+executionRoleArn: "$ROLE_ARN"
+taskRoleArn: "$ROLE_ARN"
+requiresCompatibilities:
+  - FARGATE
+ephemeralStorage:
+  sizeInGiB: 100
+volumes:
+  - name: data
+    efsVolumeConfiguration:
+      fileSystemId: "$EFS_FILESYSTEM_ID"
+      authorizationConfig:
+        accessPointId: "$EFS_ACCESS_POINT_ID"
+        iam: ENABLED
+      transitEncryption: ENABLED
+containerDefinitions:
+  - name: logs
+    image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable
+    firelensConfiguration:
+      type: fluentbit
+      options:
+        enable-ecs-log-metadata: "true"
+    memoryReservation: 50
+    logConfiguration:
+      logDriver: awslogs
+      options:
+        awslogs-group: "/analysistools/$TIER/$APP/worker"
+        awslogs-region: "$AWS_REGION"
+        awslogs-stream-prefix: logs
+
+  - name: worker
+    image: "$BACKEND_IMAGE_LATEST"
+    environment:
+      - name: TZ
+        value: "America/New_York"
+      - name: AWS_REGION
+        value: "$AWS_REGION"
+      - name: APP_NAME
+        value: "$APP"
+      - name: SERVER_PORT
+        value: "$BACKEND_CONTAINER_PORT"
+      - name: WORKER_TYPE
+        value: "fargate"
+      - name: LOG_LEVEL
+        value: "$LOG_LEVEL"
+    secrets:
+      - name: EMAIL_ADMIN
+        valueFrom: "/analysistools/$TIER/$APP/email_admin"
+      - name: EMAIL_SENDER
+        valueFrom: "/analysistools/$TIER/$APP/email_sender"
+      - name: EMAIL_BASE_URL
+        valueFrom: "/analysistools/$TIER/$APP/base_url"
+      - name: SESSION_FOLDER
+        valueFrom: "/analysistools/$TIER/$APP/session_folder"
+      - name: VPC_ID
+        valueFrom: "/analysistools/$TIER/$APP/vpc_id"
+      - name: SUBNET_IDS
+        valueFrom: "/analysistools/$TIER/$APP/subnet_ids"
+      - name: SECURITY_GROUP_IDS
+        valueFrom: "/analysistools/$TIER/$APP/security_group_ids"
+      - name: ECS_CLUSTER
+        valueFrom: "/analysistools/$TIER/$APP/ecs_cluster"
+      - name: WORKER_TASK_NAME
+        valueFrom: "/analysistools/$TIER/$APP/worker/ecs_task"
+    mountPoints:
+      - sourceVolume: data
+        containerPath: "/data"
+        readOnly: false
+    logConfiguration:
+      logDriver: awsfirelens
+      options:
+        Name: datadog
+        tls: "on"
+        tls.verify: "off"
+        dd_service: "$TIER-$APP-worker"
+        dd_source: "nodejs"
+        dd_tags: "project:$APP tier:$TIER"
+        provider: ecs
+      secretOptions:
+        - name: Host
+          valueFrom: /analysistools/$TIER/datadog/log_endpoint_host
+        - name: apikey
+          valueFrom: /analysistools/$TIER/datadog/api_key
+tags:
+  - key: Project
+    value: "$APP"
+  - key: ResourceName
+    value: "$TIER-$APP-worker-ecs-task"
+  - key: EnvironmentTier
+    value: "$ENVIRONMENT_TIER"
+  - key: ResourceFunction
+    value: compute
+  - key: Creator
+    value: CF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,178 @@
+name: Deploy
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Deploy environment"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - qa
+          - stage
+          - prod
+
+jobs:
+  deploy-fargate-app:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.tier }}
+    env:
+      APP: comets-analytics
+      TZ: America/New_York
+      AWS_REGION: us-east-1
+      TASK_DEFINITION_TEMPLATE_PATH: .github/aws
+      FRONTEND_CONTAINER_PORT: 80
+      BACKEND_CONTAINER_PORT: 8000
+      TIER: ${{ inputs.tier }}
+      IMAGE_TIER: ${{ contains(fromJson('["dev","qa"]'), inputs.tier) && 'development' || 'release' }}
+      ECS_CPU_UNITS: "2 vCPU"
+      ECS_MEMORY_UNITS: "4 GB"
+      ECS_WORKER_CPU_UNITS: "4 vCPU"
+      ECS_WORKER_MEMORY_UNITS: "16 GB"
+      CICD_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/power-user-github-actions-cicd
+
+    steps:
+      - uses: "actions/checkout@v6.0.2"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          role-to-assume: ${{ env.CICD_ROLE_ARN }}
+          role-session-name: ${{ env.TIER }}-${{ env.APP }}-deploy-${{ github.ref_name }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set dynamic environment variables
+        run: |
+          TIMESTAMP=$(date +"%Y%m%d%H%M%S")
+          REPO=${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.$AWS_REGION.amazonaws.com/$APP
+          echo "IMAGE_REPOSITORY=$REPO" >> $GITHUB_ENV
+          echo "FRONTEND_IMAGE=$REPO:$IMAGE_TIER-frontend-${{ github.ref_name }}-$TIMESTAMP" >> $GITHUB_ENV
+          echo "BACKEND_IMAGE=$REPO:$IMAGE_TIER-backend-${{ github.ref_name }}-$TIMESTAMP" >> $GITHUB_ENV
+          echo "FRONTEND_IMAGE_LATEST=$REPO:$IMAGE_TIER-frontend-${{ github.ref_name }}-latest" >> $GITHUB_ENV
+          echo "BACKEND_IMAGE_LATEST=$REPO:$IMAGE_TIER-backend-${{ github.ref_name }}-latest" >> $GITHUB_ENV
+          echo "PARAMETER_PATH=/analysistools/${TIER}/${APP}" >> $GITHUB_ENV
+          echo "ENVIRONMENT_TIER=${TIER^^}" >> $GITHUB_ENV
+
+      - name: Retrieve SSM parameters
+        run: |
+          PARAMETER_PATH="/analysistools/${TIER}/${APP}"
+
+          # Define parameters to retrieve (SSM name = ENV_VAR_NAME)
+          declare -A PARAMS=(
+            ["ecs_cluster"]="ECS_CLUSTER"
+            ["ecs_web_task"]="ECS_WEB_TASK"
+            ["ecs_web_service"]="ECS_WEB_SERVICE"
+            ["worker/ecs_task"]="ECS_WORKER_TASK"
+            ["role_arn"]="ROLE_ARN"
+            ["efs_filesystem_id"]="EFS_FILESYSTEM_ID"
+            ["efs_access_point_id"]="EFS_ACCESS_POINT_ID"
+          )
+
+          # Retrieve each parameter and export to environment
+          for ssm_name in "${!PARAMS[@]}"; do
+            env_var="${PARAMS[$ssm_name]}"
+            value=$(aws ssm get-parameter \
+              --name "${PARAMETER_PATH}/${ssm_name}" \
+              --with-decryption \
+              --query "Parameter.Value" \
+              --output text)
+            echo "${env_var}=${value}" >> $GITHUB_ENV
+            echo "Retrieved ${ssm_name} -> ${env_var}"
+          done
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.1.0
+        with:
+          mask-password: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Create and use a new builder instance
+        run: |
+          docker buildx create --name mybuilder --use
+
+      - name: Build backend image ${{ env.BACKEND_IMAGE }}
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          file: docker/backend.dockerfile
+          pull: true
+          push: true
+          tags: |
+            ${{ env.BACKEND_IMAGE }}
+            ${{ env.BACKEND_IMAGE_LATEST }}
+          cache-from: type=registry,ref=${{ env.BACKEND_IMAGE_LATEST }}
+          cache-to: type=inline
+
+      - name: Build frontend image ${{ env.FRONTEND_IMAGE }}
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          file: docker/frontend.dockerfile
+          pull: true
+          push: true
+          tags: |
+            ${{ env.FRONTEND_IMAGE }}
+            ${{ env.FRONTEND_IMAGE_LATEST }}
+          cache-from: type=registry,ref=${{ env.FRONTEND_IMAGE_LATEST }}
+          cache-to: type=inline
+
+      - name: Substitute web task definition variables
+        id: substitute-web-task-definition
+        run: |
+          echo "Substituting web task definition variables"
+          envsubst < $TASK_DEFINITION_TEMPLATE_PATH/web.yml > web.yml
+
+      - name: Substitute worker task definition variables
+        id: substitute-worker-task-definition
+        run: |
+          echo "Substituting worker task definition variables"
+          envsubst < $TASK_DEFINITION_TEMPLATE_PATH/worker.yml > worker.yml
+
+      - name: Print rendered web task definition
+        run: |
+          echo "Rendered web Task Definition:"
+          cat web.yml
+
+      - name: Print rendered worker task definition
+        run: |
+          echo "Rendered Worker Task Definition:"
+          cat worker.yml
+
+      - name: Register task definitions
+        run: |
+          aws ecs register-task-definition --cli-input-yaml file://web.yml
+          aws ecs register-task-definition --cli-input-yaml file://worker.yml
+
+      - name: Update web service
+        run: |
+          aws ecs update-service \
+              --cluster ${{ env.ECS_CLUSTER }} \
+              --service ${{ env.ECS_WEB_SERVICE }} \
+              --task-definition ${{ env.ECS_WEB_TASK }} \
+              --desired-count 1 \
+              --propagate-tags TASK_DEFINITION \
+              --force-new-deployment
+
+      - name: Remove old task definitions
+        run: |
+          for family in "$ECS_WEB_TASK" "$ECS_WORKER_TASK"; do
+              echo "Pruning old revisions for family: $family"
+              aws ecs list-task-definitions --family-prefix "$family" --sort DESC --query 'taskDefinitionArns[3:]' --output text \
+                  | xargs -n1 -r aws ecs deregister-task-definition --task-definition
+          done
+
+      - name: Deployment summary
+        run: |
+          echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tier:** ${{ env.TIER }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY

--- a/client/src/modules/home/home.jsx
+++ b/client/src/modules/home/home.jsx
@@ -98,7 +98,7 @@ export default function Home() {
               </a>
               , with web interface support from <a href="mailto:kai-ling.chen@nih.gov">Kailing Chen</a> and{" "}
               <a href="mailto:brian.park@nih.gov">Brian Park</a>{" "}
-              <a target="_blank" rel="noopener noreferrer" href="http://cbiit.nci.nih.gov/">
+              <a target="_blank" rel="noopener noreferrer" href="https://www.cancer.gov/about-nci/organization/cbiit">
                 (Center for Biomedical Informatics &amp; Information Technology, National Cancer Institute)
               </a>{" "}
               and R package development support from <a href="mailto:WheelerB@imsweb.com">Bill Wheeler</a>{" "}

--- a/docker/backend.dockerfile
+++ b/docker/backend.dockerfile
@@ -16,11 +16,17 @@ RUN dnf -y update \
    libXt-devel  \
    mariadb-connector-c-devel \
    openssl-devel \
-   R \
    readline-devel \
    rsync \
    v8-devel \
    && dnf clean all
+
+# Install R 4.4.1 from Posit (pinned to match renv.lock)
+RUN curl -O https://cdn.posit.co/r/rhel-9/pkgs/R-4.4.1-1-1.x86_64.rpm \
+   && dnf -y install R-4.4.1-1-1.x86_64.rpm \
+   && rm R-4.4.1-1-1.x86_64.rpm \
+   && ln -s /opt/R/4.4.1/bin/R /usr/local/bin/R \
+   && ln -s /opt/R/4.4.1/bin/Rscript /usr/local/bin/Rscript
 
 RUN mkdir -p /server
 
@@ -30,7 +36,7 @@ options(\
     renv.config.repos.override = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/rhel9/latest"),\
     HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(), paste(getRversion(), R.version["platform"], R.version["arch"], R.version["os"])),\
     Ncpus = parallel::detectCores()\
-)' >> /usr/lib64/R/library/base/R/Rprofile
+)' >> /opt/R/4.4.1/lib/R/library/base/R/Rprofile
 
 # install R packages with renv
 COPY server/renv.lock /server/


### PR DESCRIPTION
[NCIATWP-10087](https://tracker.nci.nih.gov/browse/NCIATWP-10087)

## Summary

- Updated broken CBIIT hyperlink on the home page to point to the current URL (`https://www.cancer.gov/about-nci/organization/cbiit`)
- Added GitHub Actions deployment workflow and ECS task definitions (from `dev` branch) to enable CI/CD from this branch
- Pinned R to version 4.4.1 in the backend Dockerfile to fix build failures caused by EPEL upgrading to R 4.5.3, which removed `Calloc`/`Free` C macros and breaks renv package compilation

## Changes

- `client/src/modules/home/home.jsx` — Fixed CBIIT link (old `http://cbiit.nci.nih.gov/` → `https://www.cancer.gov/about-nci/organization/cbiit`)
- `docker/backend.dockerfile` — Removed EPEL R package, installed Posit R 4.4.1 RPM to match `renv.lock`
- `.github/workflows/deploy.yml` — Added deployment pipeline
- `.github/aws/web.yml` — Added ECS web task definition
- `.github/aws/worker.yml` — Added ECS worker task definition
