### PR TITLE
NCIATWP-9357: Section 508 fixes (navbar tab contrast, Cohort Specific Analysis Results form label)

### DIFF
--- a/client/src/modules/analysis/results/model-results.utils.jsx
+++ b/client/src/modules/analysis/results/model-results.utils.jsx
@@ -44,12 +44,20 @@ export function getSelectColumn(onSelect) {
     ),
     SecondaryHeader: ({ getToggleAllRowsSelectedProps }) => (
       <div className="form-check">
-        <IndeterminateCheckbox {...getToggleAllRowsSelectedProps()} className="form-check-input" />
+        <IndeterminateCheckbox
+          {...getToggleAllRowsSelectedProps()}
+          className="form-check-input"
+          aria-label="Select all rows"
+        />
       </div>
     ),
     Cell: ({ row }) => (
       <div className="form-check">
-        <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} className="form-check-input" />
+        <IndeterminateCheckbox
+          {...row.getToggleRowSelectedProps()}
+          className="form-check-input"
+          aria-label="Select row"
+        />
       </div>
     ),
   };
@@ -78,6 +86,7 @@ export function getColumns(table) {
       id: columnName,
       accessor: (record) => record[columnName],
       sortType: isNumericColumn ? "basic" : "alphanumeric",
+      aria: `Filter by ${columnName}`,
       ...columnFilter,
       ...columnWidth,
     };

--- a/client/src/styles/bootstrap-theme.scss
+++ b/client/src/styles/bootstrap-theme.scss
@@ -59,18 +59,21 @@ a,
 }
 
 .navbar-dark.bg-orange {
+  // Darker orange so white nav-link text meets WCAG AA (white #ffffff on #b8500c = 5.01:1)
+  background-color: #b8500c !important;
+
   .navbar-nav .nav-link {
-    color: #ffffff; // Changed from $light to pure white for better contrast with orange
+    color: #ffffff; // white on #b8500c = 5.01:1 (AA pass)
 
     &:hover,
     &:focus {
       color: #ffffff;
-      background-color: #fd7e14;
+      background-color: #a2470b; // slightly darker on hover/focus, keeps white at 6.1:1
     }
 
     &.active {
       color: #000000; // Changed to pure black for better contrast with yellow
-      background-color: #ffc107; // Using a bright yellow for better contrast
+      background-color: #ffc107; // Using a bright yellow for better contrast (black on #ffc107 = 12.88:1)
     }
   }
 }


### PR DESCRIPTION
## Ticket(s)
[NCIATWP-9357](https://tracker.nci.nih.gov/browse/NCIATWP-9357)

## Summary of changes

### 1. Navbar tab color contrast (Serious, 2 instances) — WCAG 2 AA 1.4.3
File: `client/src/styles/bootstrap-theme.scss` (`.navbar-dark.bg-orange`)

The two inactive (non-current) navbar tabs rendered white text `#ffffff` on the bright orange bar `#fd7e14`, giving a contrast ratio of only **2.57:1** (fails the 4.5:1 AA minimum).

- Darkened the navbar background to `#b8500c`: white nav-link text now measures **5.01:1** (AA pass).
- Darkened the hover/focus tab background to `#a2470b`: white text measures **6.10:1** (AA pass).
- The active tab was already compliant — black `#000000` on yellow `#ffc107` = **12.88:1** — and is unchanged.

The background override is scoped to the navbar (`.navbar-dark.bg-orange`), so the shared `.bg-orange` utility used elsewhere is not affected.

### 2. Form element without a label on Results (Critical, 1 instance) — WCAG 2 A 4.1.2 / 1.3.1
File: `client/src/modules/analysis/results/model-results.utils.jsx`

The row-selection checkboxes in the model results table (`getSelectColumn`) had no accessible name.

- Added `aria-label="Select all rows"` to the header "select all" checkbox.
- Added `aria-label="Select row"` to each per-row checkbox.
- Additionally gave the results column filter inputs a meaningful accessible name by setting a per-column `aria` value (`Filter by <column>`) in `getColumns`. The filter inputs (`TextFilter`/`RangeFilter` in `client/src/modules/common/table.jsx`) previously received `aria-label={undefined}` because no `aria` was passed; they now get a descriptive label, matching the existing `aria-label` pattern already used by the page-size `<select>` in that table.

## Where the reviewer can test
- **Navbar contrast:** Any page. The top orange navbar shows Home / Single Cohort Analysis / Meta-Analysis / About. Whichever tab is current renders as the yellow active pill; the other tabs are the inactive white-on-orange text. Verify with axe DevTools (or a contrast checker) that the inactive tabs now meet 4.5:1 against the darker orange bar.
- **Results form label:** Go to **Single Cohort Analysis**, run a model so results populate, then open the **Results** tab. Inspect the leftmost selection column checkboxes (header "select all" and per-row) and the per-column filter inputs — each now exposes an accessible name (aria-label). axe should no longer report "Form elements must have labels" on this view.