### PR TITLE
Fix backend Docker build: pin dbplyr to 2.5.2 (dplyr 1.1.4 compatibility)

### DIFF
--- a/docker/backend.dockerfile
+++ b/docker/backend.dockerfile
@@ -65,7 +65,11 @@ RUN R -e "\
    renv::snapshot();"
 
 # install RaMP package from GitHub and its Bioconductor dependency
-RUN R -e "renv::install('bioc::BiocFileCache'); renv::install('ncats/RaMP-DB')"
+# Pin dbplyr to 2.5.2 (last version compatible with the project's dplyr 1.1.4).
+# dbplyr 2.6.0 (2026-06-17) is pulled in transitively by BiocFileCache and calls
+# dplyr::filter_out, which is not exported by CRAN dplyr 1.1.4, so the unpinned
+# install breaks the build. Installing 2.5.2 first makes BiocFileCache use it.
+RUN R -e "renv::install('dbplyr@2.5.2'); renv::install('bioc::BiocFileCache'); renv::install('ncats/RaMP-DB')"
 
 COPY server /server/
 


### PR DESCRIPTION
## Summary of changes
Fixes the backend Docker image build failure at the `renv::install('bioc::BiocFileCache')` step in `docker/backend.dockerfile`.

**Root cause:** `BiocFileCache` pulls in `dbplyr` as a transitive dependency. The current **dbplyr 2.6.0** (released 2026-06-17) calls `dplyr::filter_out`, which is **not exported by the project's pinned `dplyr 1.1.4`** (the newest `dplyr` on CRAN). `dbplyr` fails to load → `BiocFileCache` install fails → the image build exits 1. This began after 2026-06-17; the last green backend build was 2026-05-21 (dbplyr 2.5.2 was current then).

**Fix:** pin `dbplyr` to **2.5.2** (last version compatible with `dplyr 1.1.4`) and install it before `BiocFileCache` so the transitive resolution uses it:
```dockerfile
RUN R -e "renv::install('dbplyr@2.5.2'); renv::install('bioc::BiocFileCache'); renv::install('ncats/RaMP-DB')"
```

This is a build-infra fix only — no application or analysis code changes, and `dplyr` (used by the core analysis packages) is left untouched.

## Where the reviewer can test
Run the **Deploy** workflow for this branch to the **dev** environment; the backend image build should now complete past step `[13/14] RUN R -e "renv::install('bioc::BiocFileCache')..."`. (The build was failing there for the `dev` and `dev_9357` deploy runs on 2026-07-02/07-06.)

## Other info
- Not tied to a feature ticket — this is a CI/deploy build break caused by upstream dbplyr drift.
- Follow-up option (not in this PR): pin `docker/backend.dockerfile` line 68 to a dated Posit Package Manager snapshot to prevent future transitive-dependency drift.
